### PR TITLE
WIP: Broader Store Searches

### DIFF
--- a/pizzapi/address.py
+++ b/pizzapi/address.py
@@ -45,8 +45,22 @@ class Address(object):
         nearby_stores will filter the information we receive from the API
         to exclude stores that are not currently online (!['IsOnlineNow']),
         and stores that are not currently in service (!['ServiceIsOpen']).
+
+        (city and region) or (postalcode) is required to get a result from
+        the API. This is enforced in the tests, but not in these methods,
+        since the API might change in the future. 
         """
-        data = request_json(self.urls.find_url(), line1=self.line1, line2=self.line2, type=service)
+        data = request_json(
+            self.urls.find_url(), 
+            line1=self.line1, 
+            line2=self.line2, 
+            type=service
+        )
+
+        if data['Status'] == -1:
+            # This is an error from the Domino's API. 
+            raise Exception(data['StatusItems'])
+
         return [Store(x, self.country) for x in data['Stores']
                 if x['IsOnlineNow'] and x['ServiceIsOpen'][service]]
 

--- a/tests/fixtures/stores_failure.json
+++ b/tests/fixtures/stores_failure.json
@@ -1,0 +1,1 @@
+{"Status": -1, "StatusItems": [{"Code": "MissingCityRegionOrPostalCode"}], "Address": {"City": "", "Region": "MN", "UnitType": "", "UnitNumber": "", "StreetNumber": "", "PostalCode": "", "StreetName": "", "Street": ""}, "Stores": [], "Granularity": "Unknown"}


### PR DESCRIPTION
Allow the user to more broadly query the API to gather information about nearby stores. Additional tests and fixtures to support this functionality. 

Still pending, enforcing that a full street address be populated when placing an order.