### PR TITLE
add missing import statement to make code work as written

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,13 @@ It's a port of `the pizzapi node.js module <https://github.com/RIAEvangelist/nod
 Quick Start
 -----------
 
-First construct a ``Customer`` object and set the customer's address:
+Pull the module into your namespace:
+
+.. code-block:: python
+
+    from pizzapi import *
+
+First, construct a ``Customer`` object and set the customer's address:
 
 .. code-block:: python
 


### PR DESCRIPTION
If you just run `import pizzapi`, the README won't work as expected. 