### PR TITLE
setuptools-based testing works as expected

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[aliases]
+test=pytest

--- a/setup.py
+++ b/setup.py
@@ -113,7 +113,7 @@ setup(
 
     # You can just specify the packages manually here if your project is
     # simple. Or you can use find_packages().
-    packages=find_packages(exclude=['tests']),
+    packages=find_packages(),
 
     # TODO: Add a command line tool
     # To provide executable scripts, use entry points in preference to the
@@ -139,6 +139,7 @@ setup(
         'mock',
         'pytest',
     ],
+    setup_requires=["pytest-runner"],
 
     # setup.py publish support.
     cmdclass={


### PR DESCRIPTION
`python setup.py test` was not working - you had to call the pytest module directly, which wasn't intuitive. Now, it just works! 